### PR TITLE
Support for proxy servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,16 @@ VOLUME [ "/toolkit_tarballs" ]
 
 ENV IS_IN_CONTAINER 1
 
+# Uncomment to use a proxy server
+#ENV http_proxy=http://proxy:8000
+#ENV https_proxy=http://proxy:8000
+
 RUN apt-get update \
  && apt-get -qy install git python3 wget ca-certificates
+
+# Uncomment to use a proxy server
+#RUN git config --global http.proxy $http_proxy \
+# && git config --global https.proxy $https_proxy
 
 COPY . /source/WireGuard
 


### PR DESCRIPTION
On my network I need to make HTTP requests through a proxy server. This change shows how to do it, namely setting both `http_proxy` and then configuring `git` to use it as well.